### PR TITLE
update to 1.21.5 fabric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.8-SNAPSHOT'
+    id 'fabric-loom' version '1.10-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,12 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.1
-loader_version=0.16.9
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.13
 # Mod Properties
-mod_version=1.21.4-v1b-fabric
+mod_version=1.21.5-v1a-fabric
 maven_group=lain.mods.peacefulsurface
 archives_base_name=peacefulsurface
 # Dependencies
-fabric_version=0.110.5+1.21.4
+fabric_version=0.120.0+1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/lain/mods/peacefulsurface/init/fabric/mixins/FabricPeacefulSurfaceMixin.java
+++ b/src/main/java/lain/mods/peacefulsurface/init/fabric/mixins/FabricPeacefulSurfaceMixin.java
@@ -19,7 +19,7 @@ public abstract class FabricPeacefulSurfaceMixin {
 
     @Inject(method = "canSpawn(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/SpawnGroup;Lnet/minecraft/world/gen/StructureAccessor;Lnet/minecraft/world/gen/chunk/ChunkGenerator;Lnet/minecraft/world/biome/SpawnSettings$SpawnEntry;Lnet/minecraft/util/math/BlockPos$Mutable;D)Z", at = @At("RETURN"), cancellable = true)
     private static void onCanSpawn_nBXjeY(ServerWorld world, SpawnGroup group, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, SpawnSettings.SpawnEntry spawnEntry, BlockPos.Mutable pos, double squaredDistance, CallbackInfoReturnable<Boolean> info) {
-        if (info.getReturnValue() && PeaceAPI.filterEntity(FabricPeacefulSurface.wrapEntity(spawnEntry.type), FabricPeacefulSurface.wrapWorld(world), pos.getX(), pos.getY(), pos.getZ()))
+        if (info.getReturnValue() && PeaceAPI.filterEntity(FabricPeacefulSurface.wrapEntity(spawnEntry.type()), FabricPeacefulSurface.wrapWorld(world), pos.getX(), pos.getY(), pos.getZ()))
             info.setReturnValue(false);
     }
 


### PR DESCRIPTION
Hi @zlainsama,

I keep a personal clone of this repo with some minor tweaks for my own uses.

I just updated my clone to 1.21.5 (fabric) and confirmed that it's working in my singleplayer world.

This PR replays the changes I made, in case you'd like to save some effort updating your mod to the new version.

The only change that wasn't just a config update was `spawnEntry.type` -> `spawnEntry.type()`. That field has become private and needs to be [accessed with a method](https://maven.fabricmc.net/docs/yarn-1.21.5+build.1/net/minecraft/world/biome/SpawnSettings.SpawnEntry.html#type()) now.

Thanks for a great mod!